### PR TITLE
WIP: Add support for multiple shadows

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -1001,6 +1001,12 @@ void C_BaseEntity::Clear( void )
 	m_ShadowHandles.Purge();
 	m_ShadowHandles.AddToTail(CLIENTSHADOW_INVALID_HANDLE);
 	Assert(m_ShadowHandles.Count() == 1);
+
+	m_ShadowAlphaFractions.Purge();
+	m_ShadowAlphaFractions.AddToTail(1);
+	Assert(m_ShadowAlphaFractions.Count() == 1);
+
+	Assert(m_ShadowHandles.Count() == m_ShadowAlphaFractions.Count());
 #else
 	m_ShadowHandle = CLIENTSHADOW_INVALID_HANDLE;
 #endif
@@ -3575,7 +3581,8 @@ void C_BaseEntity::ComputeFxBlend( void )
 			Assert(false);
 			break;
 		}
-		g_pClientShadowMgr->SetFalloffBias(shadow, (255 / nShadows - m_nRenderFXBlend));
+		const int alpha = int(255 * m_ShadowAlphaFractions[i]);
+		g_pClientShadowMgr->SetFalloffBias(shadow, (alpha / nShadows - m_nRenderFXBlend));
 	}
 #else
 	if ( m_ShadowHandle != CLIENTSHADOW_INVALID_HANDLE )
@@ -4012,6 +4019,7 @@ void C_BaseEntity::CreateShadow()
 				if (shadowType == SHADOWS_RENDER_TO_TEXTURE_DYNAMIC)
 					flags |= SHADOW_FLAGS_ANIMATING_SOURCE;
 				m_ShadowHandles[i] = g_pClientShadowMgr->CreateShadow(GetClientHandle(), flags);
+				m_ShadowAlphaFractions[i] = 1.0;
 			}
 		}
 #else
@@ -4045,6 +4053,7 @@ void C_BaseEntity::DestroyShadow()
 		{
 			g_pClientShadowMgr->DestroyShadow(shadow);
 			m_ShadowHandles[i] = CLIENTSHADOW_INVALID_HANDLE;
+			m_ShadowAlphaFractions[i] = 0;
 		}
 	}
 #else

--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -3564,12 +3564,18 @@ void C_BaseEntity::ComputeFxBlend( void )
 
 	// Tell our shadow
 #ifdef NEO
-	for (int i = 0;; ++i)
+	const auto nShadows = ShadowHandles().Count();
+	for (int i = 0; i < nShadows; ++i)
 	{
 		auto shadow = GetShadowHandle(i);
-		if (!IsValidShadowHandle(shadow))
+		if (shadow == CLIENTSHADOW_INVALID_HANDLE)
+			continue;
+		if (shadow == CLIENTSHADOW_OUT_OF_RANGE)
+		{
+			Assert(false);
 			break;
-		g_pClientShadowMgr->SetFalloffBias(shadow, (255 - m_nRenderFXBlend));
+		}
+		g_pClientShadowMgr->SetFalloffBias(shadow, (255 / nShadows - m_nRenderFXBlend));
 	}
 #else
 	if ( m_ShadowHandle != CLIENTSHADOW_INVALID_HANDLE )

--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -1180,7 +1180,19 @@ public:
 	virtual ModelInstanceHandle_t GetModelInstance() { return m_ModelInstance; }
 	void SetModelInstance( ModelInstanceHandle_t hInstance) { m_ModelInstance = hInstance; }
 	bool SnatchModelInstance( C_BaseEntity * pToEntity );
+#ifdef NEO
+	virtual ClientShadowHandle_t GetShadowHandle(int i) const
+	{
+		if (i >= m_ShadowHandles.Count() || i < 0)
+		{
+			Assert(i >= 0);
+			return CLIENTSHADOW_OUT_OF_RANGE;
+		}
+		return m_ShadowHandles[i];
+	}
+#else
 	virtual ClientShadowHandle_t GetShadowHandle() const	{ return m_ShadowHandle; }
+#endif
 	virtual ClientRenderHandle_t&	RenderHandle();
 
 	void CreateModelInstance();
@@ -1566,7 +1578,17 @@ private:
 	ModelInstanceHandle_t			m_ModelInstance;
 
 	// Shadow data
+#ifdef NEO
+	CUtlVector<ClientShadowHandle_t> m_ShadowHandles;
+protected:
+	CUtlVector<ClientShadowHandle_t>& ShadowHandles()
+	{
+		return m_ShadowHandles;
+	}
+private:
+#else
 	ClientShadowHandle_t			m_ShadowHandle;
+#endif
 
 	// A random value used by material proxies for each model instance.
 	float							m_flProxyRandomValue;

--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -1580,10 +1580,16 @@ private:
 	// Shadow data
 #ifdef NEO
 	CUtlVector<ClientShadowHandle_t> m_ShadowHandles;
+	CUtlVector<vec_t> m_ShadowAlphaFractions;
+	friend class CClientShadowMgr;
 protected:
 	CUtlVector<ClientShadowHandle_t>& ShadowHandles()
 	{
 		return m_ShadowHandles;
+	}
+	CUtlVector<vec_t>& ShadowAlphaFractions()
+	{
+		return m_ShadowAlphaFractions;
 	}
 private:
 #else

--- a/src/game/client/c_prop_vehicle.cpp
+++ b/src/game/client/c_prop_vehicle.cpp
@@ -187,7 +187,17 @@ ShadowType_t C_PropVehicleDriveable::ShadowCastType()
 void C_PropVehicleDriveable::ClientThink( void )
 {
 	// The vehicle is always dirty owing to pose parameters while it's being driven.
+#ifdef NEO
+	for (int i = 0;; ++i)
+	{
+		auto shadow = GetShadowHandle(i);
+		if (shadow == CLIENTSHADOW_OUT_OF_RANGE)
+			break;
+		g_pClientShadowMgr->MarkRenderToTextureShadowDirty( shadow );
+	}
+#else
 	g_pClientShadowMgr->MarkRenderToTextureShadowDirty( GetShadowHandle() );
+#endif
 }
 
 

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -4421,7 +4421,8 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 			}
 		}
 
-		if (g_pWorldLights->GetNthBrightestLightSource(nthShadow, pRenderable->GetRenderOrigin(), lightPos, lightBrightness) == false
+		vec_t relativeBrightness;
+		if (!g_pWorldLights->GetNthBrightestLightSource(nthShadow, pRenderable->GetRenderOrigin(), lightPos, lightBrightness, relativeBrightness)
 			|| lightBrightness.LengthSqr() < flMinBrightnessSqr)
 #else
 		if (g_pWorldLights->GetBrightestLightSource(pRenderable->GetRenderOrigin(), lightPos, lightBrightness) == false || lightBrightness.LengthSqr() < flMinBrightnessSqr)
@@ -4430,6 +4431,14 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 			// Didn't find a light source at all, use default shadow direction
 			// TODO: Could switch to using blobby shadow in this case
 			lightPos.Init(FLT_MAX, FLT_MAX, FLT_MAX);
+			if (pEnt)
+			{
+				pEnt->m_ShadowAlphaFractions[nthShadow] = 1;
+			}
+		}
+		else if (pEnt)
+		{
+			pEnt->m_ShadowAlphaFractions[nthShadow] = relativeBrightness;
 		}
 	}
 

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -4364,7 +4364,7 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 	}
 	else if (shadow.m_LightPosLerp < 1.0f)
 	{
-		// We're in the middle of a lerp from current to target light. Finish it if they are moving.
+		// We're in the middle of a lerp from current to target light. Finish it if they aren't moving.
 		if (speed > 20.0f)
 		{
 			shadow.m_LightPosLerp += gpGlobals->frametime * normalisedSpeed;

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -97,7 +97,7 @@ static ConVar r_flashlight_version2( "r_flashlight_version2", "0", FCVAR_CHEAT |
 #ifdef NEO
 void WorldLightCastShadowCallback(IConVar* pVar, const char* pszOldValue, float flOldValue);
 static ConVar r_worldlight_castshadows("r_worldlight_castshadows", "1", FCVAR_CHEAT, "Allow world lights to cast shadows", true, 0, true, 1, WorldLightCastShadowCallback);
-static ConVar r_worldlight_lerpmaxobjectvel("r_worldlight_lerpmaxobjectvel", "130.0", FCVAR_CHEAT, "The speed the object must be moving in order to make the transition between lights reach maximum speed");
+static ConVar r_worldlight_lerptime("r_worldlight_lerptime", "0.5", FCVAR_CHEAT);
 static ConVar r_worldlight_debug("r_worldlight_debug", "0", FCVAR_CHEAT);
 static ConVar r_worldlight_shortenfactor("r_worldlight_shortenfactor", "2", FCVAR_CHEAT, "Makes shadows cast from local lights shorter");
 static ConVar r_worldlight_mincastintensity("r_worldlight_mincastintensity", "0.3", FCVAR_CHEAT, "Minimum brightness of a light to be classed as shadow casting", true, 0, false, 0);
@@ -4344,12 +4344,6 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 		}
 	}
 
-	// NEO NOTE DG: Comparing the origin to the last origin isnt viable because prediction(?)
-	// makes players never still. lets check the speed to see if they are moving
-	Vector delta = pRenderable->GetRenderOrigin() - shadow.m_LastOrigin;
-	float speed = delta.Length() / gpGlobals->frametime;
-	float normalisedSpeed = clamp( speed / r_worldlight_lerpmaxobjectvel.GetFloat(), 0.0f, 0.5f);
-
 	if (shadow.m_LightPosLerp == FLT_MAX)	// First light pos ever, just init
 	{
 		shadow.m_CurrentLightPos = lightPos;
@@ -4358,12 +4352,9 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 	}
 	else if (shadow.m_LightPosLerp < 1.0f)
 	{
-		// We're in the middle of a lerp from current to target light. Finish it if they aren't moving.
-		if (speed > 20.0f)
-		{
-			shadow.m_LightPosLerp += gpGlobals->frametime * normalisedSpeed;
-			shadow.m_LightPosLerp = clamp(shadow.m_LightPosLerp, 0.0f, 1.0f);
-		}
+		// We're in the middle of a lerp from current to target light. Finish it.
+		shadow.m_LightPosLerp += gpGlobals->frametime * 1.0f / r_worldlight_lerptime.GetFloat();
+		shadow.m_LightPosLerp = clamp(shadow.m_LightPosLerp, 0.0f, 1.0f);
 
 		Vector currLightPos(shadow.m_CurrentLightPos);
 		Vector targetLightPos(shadow.m_TargetLightPos);

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -4322,17 +4322,11 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 		return;
 	}
 
-	// NEO NOTE DG: Using the bounding box for this will make the shadow jump around. Undone below
-	// They may appear to jump on walls sometimes, but this behaviour is visible on master currently
-	// NEO TODO: find out whats causing the size to change 3 times when player stops moving
-#if 0
 	Vector bbMin, bbMax;
 	pRenderable->GetRenderBoundsWorldspace(bbMin, bbMax);
 	Vector origin(0.5f * (bbMin + bbMax));
 	origin.z = bbMin.z; // Putting origin at the bottom of the bounding box makes the shadows a little shorter
-#endif
 
-	Vector origin = pRenderable->GetRenderOrigin();
 	Vector lightPos;
 	Vector lightBrightness;
 

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -4333,7 +4333,6 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 #endif
 
 	Vector origin = pRenderable->GetRenderOrigin();
-	Vector objectCenter = pRenderable->GetIClientUnknown()->GetBaseEntity()->WorldSpaceCenter();
 	Vector lightPos;
 	Vector lightBrightness;
 
@@ -4343,7 +4342,7 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 		float flMinBrightnessSqr = r_worldlight_mincastintensity.GetFloat();
 		flMinBrightnessSqr *= flMinBrightnessSqr;
 
-		if (g_pWorldLights->GetBrightestLightSource(objectCenter, lightPos, lightBrightness) == false || lightBrightness.LengthSqr() < flMinBrightnessSqr)
+		if (g_pWorldLights->GetBrightestLightSource(pRenderable->GetRenderOrigin(), lightPos, lightBrightness) == false || lightBrightness.LengthSqr() < flMinBrightnessSqr)
 		{
 			// Didn't find a light source at all, use default shadow direction
 			// TODO: Could switch to using blobby shadow in this case
@@ -4353,7 +4352,7 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 
 	// NEO NOTE DG: Comparing the origin to the last origin isnt viable because prediction(?)
 	// makes players never still. lets check the speed to see if they are moving
-	Vector delta = origin - shadow.m_LastOrigin;
+	Vector delta = pRenderable->GetRenderOrigin() - shadow.m_LastOrigin;
 	float speed = delta.Length() / gpGlobals->frametime;
 	float normalisedSpeed = clamp( speed / r_worldlight_lerpmaxobjectvel.GetFloat(), 0.0f, 0.5f);
 
@@ -4446,7 +4445,7 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 
 	if (r_worldlight_debug.GetBool())
 	{
-		NDebugOverlay::Line(lightPos, objectCenter, 255, 255, 0, false, 0.0f);
+		NDebugOverlay::Line(lightPos, origin, 255, 255, 0, false, 0.0f);
 	}
 }
 

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -4422,7 +4422,7 @@ void CClientShadowMgr::UpdateShadowDirectionFromLocalLightSource(ClientShadowHan
 		}
 
 		vec_t relativeBrightness;
-		if (!g_pWorldLights->GetNthBrightestLightSource(nthShadow, pRenderable->GetRenderOrigin(), lightPos, lightBrightness, relativeBrightness)
+		if (!g_pWorldLights->GetNthBrightestLightSource(nthShadow, pRenderable, pRenderable->GetRenderOrigin(), lightPos, lightBrightness, relativeBrightness)
 			|| lightBrightness.LengthSqr() < flMinBrightnessSqr)
 #else
 		if (g_pWorldLights->GetBrightestLightSource(pRenderable->GetRenderOrigin(), lightPos, lightBrightness) == false || lightBrightness.LengthSqr() < flMinBrightnessSqr)

--- a/src/game/client/detailobjectsystem.cpp
+++ b/src/game/client/detailobjectsystem.cpp
@@ -168,7 +168,11 @@ public:
 	virtual bool				IgnoresZBuffer( void ) const { return false; }
 	virtual bool				LODTest() { return true; }
 
+#ifdef NEO
+	virtual ClientShadowHandle_t	GetShadowHandle(int i) const override;
+#else
 	virtual ClientShadowHandle_t	GetShadowHandle() const;
+#endif
 	virtual ClientRenderHandle_t&	RenderHandle();
 	virtual void				GetShadowRenderBounds( Vector &mins, Vector &maxs, ShadowType_t shadowType );
 	virtual bool IsShadowDirty( )			     { return false; }
@@ -635,7 +639,11 @@ void CDetailModel::GetShadowRenderBounds( Vector &mins, Vector &maxs, ShadowType
 	GetRenderBounds( mins, maxs );
 }
 
+#ifdef NEO
+ClientShadowHandle_t CDetailModel::GetShadowHandle(int i) const
+#else
 ClientShadowHandle_t CDetailModel::GetShadowHandle() const
+#endif
 {
 	return CLIENTSHADOW_INVALID_HANDLE;
 }

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -495,8 +495,8 @@ ConCommand vguicancel("vguicancel", &vguiCancel_Cb, "Cancel current vgui screen.
 
 C_NEO_Player::C_NEO_Player()
 {
-	//ShadowHandles().AddToTail(CLIENTSHADOW_INVALID_HANDLE);
-	Assert(ShadowHandles().Count() == 1);
+	ShadowHandles().AddToTail(CLIENTSHADOW_INVALID_HANDLE);
+	Assert(ShadowHandles().Count() == 2);
 
 	SetPredictionEligible(true);
 

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -496,7 +496,9 @@ ConCommand vguicancel("vguicancel", &vguiCancel_Cb, "Cancel current vgui screen.
 C_NEO_Player::C_NEO_Player()
 {
 	ShadowHandles().AddToTail(CLIENTSHADOW_INVALID_HANDLE);
+	ShadowAlphaFractions().AddToTail(1);
 	Assert(ShadowHandles().Count() == 2);
+	Assert(ShadowAlphaFractions().Count() == ShadowHandles().Count());
 
 	SetPredictionEligible(true);
 

--- a/src/game/client/neo/c_neo_player.cpp
+++ b/src/game/client/neo/c_neo_player.cpp
@@ -495,6 +495,9 @@ ConCommand vguicancel("vguicancel", &vguiCancel_Cb, "Cancel current vgui screen.
 
 C_NEO_Player::C_NEO_Player()
 {
+	//ShadowHandles().AddToTail(CLIENTSHADOW_INVALID_HANDLE);
+	Assert(ShadowHandles().Count() == 1);
+
 	SetPredictionEligible(true);
 
 	m_iNeoClass = NEORules()->GetForcedClass() >= 0 ? NEORules()->GetForcedClass() : NEO_CLASS_ASSAULT;

--- a/src/game/client/neo/worldlight.cpp
+++ b/src/game/client/neo/worldlight.cpp
@@ -180,8 +180,14 @@ void CWorldLights::LevelInitPreEntity()
 }
 
 #ifdef NEO
-// Find the nth brightest light source at a point, zero-indexed
-bool CWorldLights::GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness)
+// Finds the nth brightest light source at a point, zero-indexed.
+// Returns boolean of whether such a light source was found.
+// Passes the light position, brightness, and relative brightness by reference.
+// "relativeBrightness" is the fraction of the output vecLightBrightness's squared magnitude
+// in relation to the (n-1)th squared magnitude, or 1.0 if n equals 0 or (n-1)th magnitude equals 0.
+// Out variable contents are indeterminate if the return value is false.
+bool CWorldLights::GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness,
+	vec_t& relativeBrightness)
 #else
 //-----------------------------------------------------------------------------
 // Purpose: Find the brightest light source at a point
@@ -328,6 +334,18 @@ bool CWorldLights::GetBrightestLightSource(const Vector& vecPosition, Vector& ve
 	const auto& res = brightest.Element(n);
 	vecLightPos = res.first;
 	vecLightBrightness = res.second;
+
+	if (n == 0)
+	{
+		relativeBrightness = 1;
+	}
+	else
+	{
+		const auto& prev = brightest.Element(n - 1);
+		const auto prevLenSqr = prev.second.LengthSqr();
+		relativeBrightness = prevLenSqr ? res.second.LengthSqr() / prevLenSqr : 1;
+	}
+	Assert(relativeBrightness >= 0 && relativeBrightness <= 1);
 #endif
 	return !vecLightBrightness.IsZero();
 }

--- a/src/game/client/neo/worldlight.h
+++ b/src/game/client/neo/worldlight.h
@@ -28,7 +28,7 @@ public:
 	~CWorldLights() { Clear(); }
 
 #ifdef NEO
-	bool GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness, vec_t& relativeBrightness);
+	bool GetNthBrightestLightSource(int n, const IClientRenderable* pRenderable, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness, vec_t& relativeBrightness);
 #else
 	bool GetBrightestLightSource(const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness);
 #endif

--- a/src/game/client/neo/worldlight.h
+++ b/src/game/client/neo/worldlight.h
@@ -28,7 +28,7 @@ public:
 	~CWorldLights() { Clear(); }
 
 #ifdef NEO
-	bool GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness);
+	bool GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness, vec_t& relativeBrightness);
 #else
 	bool GetBrightestLightSource(const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness);
 #endif

--- a/src/game/client/neo/worldlight.h
+++ b/src/game/client/neo/worldlight.h
@@ -27,7 +27,11 @@ public:
 	CWorldLights();
 	~CWorldLights() { Clear(); }
 
+#ifdef NEO
+	bool GetNthBrightestLightSource(int n, const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness);
+#else
 	bool GetBrightestLightSource(const Vector& vecPosition, Vector& vecLightPos, Vector& vecLightBrightness);
+#endif
 
 	// CAutoGameSystem overrides
 	bool Init() OVERRIDE;

--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -1476,7 +1476,17 @@ void CBaseEntity::InvalidatePhysicsRecursive( int nChangeFlags )
 #ifdef CLIENT_DLL
 			MarkRenderHandleDirty();
 			g_pClientShadowMgr->AddToDirtyShadowList( this );
+#ifdef NEO
+			for (int i = 0;; ++i)
+			{
+				auto shadow = GetShadowHandle(i);
+				if (!IsValidShadowHandle(shadow))
+					break;
+				g_pClientShadowMgr->MarkRenderToTextureShadowDirty(shadow);
+			}
+#else
 			g_pClientShadowMgr->MarkRenderToTextureShadowDirty( GetShadowHandle() );
+#endif
 #endif
 		}
 
@@ -1492,7 +1502,17 @@ void CBaseEntity::InvalidatePhysicsRecursive( int nChangeFlags )
 	if ( nChangeFlags & ANIMATION_CHANGED )
 	{
 #ifdef CLIENT_DLL
+#ifdef NEO
+		for (int i = 0;; ++i)
+		{
+			auto shadow = GetShadowHandle(i);
+			if (!IsValidShadowHandle(shadow))
+				break;
+			g_pClientShadowMgr->MarkRenderToTextureShadowDirty(shadow);
+		}
+#else
 		g_pClientShadowMgr->MarkRenderToTextureShadowDirty( GetShadowHandle() );
+#endif
 #endif
 
 		// Only set this flag if the only thing that changed us was the animation.

--- a/src/game/shared/collisionproperty.cpp
+++ b/src/game/shared/collisionproperty.cpp
@@ -1240,7 +1240,17 @@ void CCollisionProperty::MarkSurroundingBoundsDirty()
 	MarkPartitionHandleDirty();
 
 #ifdef CLIENT_DLL
+#ifdef NEO
+	for (int i = 0;; ++i)
+	{
+		auto shadow = GetOuter()->GetShadowHandle(i);
+		if (!IsValidShadowHandle(shadow))
+			break;
+		g_pClientShadowMgr->MarkRenderToTextureShadowDirty(shadow);
+	}
+#else
 	g_pClientShadowMgr->MarkRenderToTextureShadowDirty( GetOuter()->GetShadowHandle() );
+#endif
 #else
 	GetOuter()->NetworkProp()->MarkPVSInformationDirty();
 #endif

--- a/src/game/shared/neo/weapons/weapon_knife.cpp
+++ b/src/game/shared/neo/weapons/weapon_knife.cpp
@@ -113,18 +113,7 @@ bool CWeaponKnife::CanBePickedUpByClass(int classId)
 bool CWeaponKnife::ShouldDraw()
 {
 	auto owner = static_cast<CNEO_Player*>(GetOwner());
-	bool draw = (owner && owner->IsAlive() && owner->GetActiveWeapon() == this);
-
-	if (draw) // DG: Disable shadows manually because it doesn't do it on its own
-	{
-		RemoveEffects(EF_NOSHADOW);
-	}
-	else
-	{
-		AddEffects(EF_NOSHADOW);
-	}
-
-	return draw;
+	return (owner && owner->IsAlive() && owner->GetActiveWeapon() == this);
 }
 #else
 bool CWeaponKnife::IsViewable()

--- a/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
+++ b/src/game/shared/neo/weapons/weapon_neobasecombatweapon.cpp
@@ -345,9 +345,11 @@ void CNEOBaseCombatWeapon::Equip(CBaseCombatCharacter* pOwner)
 	}
 	else if (weapon & NEO_WEP_KNIFE)
 	{
+		AddEffects(EF_NOSHADOW);
 		return;
 	}
 	else
+		RemoveEffects(EF_NOSHADOW);
 		SetParentAttachment("SetParentAttachment", "primary", false);
 #endif
 }

--- a/src/public/iclientrenderable.h
+++ b/src/public/iclientrenderable.h
@@ -29,8 +29,26 @@ typedef unsigned short ClientShadowHandle_t;
 
 enum
 {
+#ifdef NEO
+	CLIENTSHADOW_INVALID_HANDLE = ((ClientShadowHandle_t)~0)-1,
+	CLIENTSHADOW_OUT_OF_RANGE = CLIENTSHADOW_INVALID_HANDLE+1
+#else
 	CLIENTSHADOW_INVALID_HANDLE = (ClientShadowHandle_t)~0
+#endif
 };
+#ifdef NEO
+#pragma push_macro("max")
+#undef max
+static_assert(std::numeric_limits<ClientShadowHandle_t>::max()-1 == CLIENTSHADOW_INVALID_HANDLE);
+static_assert(std::numeric_limits<ClientShadowHandle_t>::max() == CLIENTSHADOW_OUT_OF_RANGE);
+#pragma pop_macro("max")
+
+inline bool IsValidShadowHandle(ClientShadowHandle_t shadowHandle)
+{
+	return shadowHandle != CLIENTSHADOW_INVALID_HANDLE && shadowHandle != CLIENTSHADOW_OUT_OF_RANGE;
+}
+#endif
+
 
 //-----------------------------------------------------------------------------
 // What kind of shadows to render?
@@ -77,7 +95,11 @@ public:
 	virtual bool					UsesPowerOfTwoFrameBufferTexture() = 0;
 	virtual bool					UsesFullFrameBufferTexture() = 0;
 
+#ifdef NEO
+	virtual ClientShadowHandle_t	GetShadowHandle(int i) const = 0;
+#else
 	virtual ClientShadowHandle_t	GetShadowHandle() const = 0;
+#endif
 
 	// Used by the leaf system to store its render handle.
 	virtual ClientRenderHandle_t&	RenderHandle() = 0;
@@ -193,10 +215,18 @@ public:
 	virtual bool					UsesPowerOfTwoFrameBufferTexture( void ) { return false; }
 	virtual bool					UsesFullFrameBufferTexture( void ) { return false; }
 
+#ifdef NEO
+	virtual ClientShadowHandle_t	GetShadowHandle(int i) const
+	{
+		Assert(i >= 0);
+		return CLIENTSHADOW_INVALID_HANDLE;
+	}
+#else
 	virtual ClientShadowHandle_t	GetShadowHandle() const
 	{
 		return CLIENTSHADOW_INVALID_HANDLE;
 	}
+#endif
 
 	virtual ClientRenderHandle_t&	RenderHandle()
 	{


### PR DESCRIPTION
WIP, not ready for merge yet!

This is a draft for supporting multiple shadows with alpha blend, for addressing some of the trouble with https://github.com/NeotokyoRebuild/neo/pull/1249

For now, I have reverted the range a68bffc7..0326a07c manually to avoid rewriting the aforementioned main neo PR history, so this is effectively based atop a021b839. If we need changes from the reverted range, we could cherry-pick them on top of this PR to re-apply them once this PR ready for merge to the main PR https://github.com/NeotokyoRebuild/neo/pull/1249.